### PR TITLE
feat: support GitHub avatar

### DIFF
--- a/node/contributor.ts
+++ b/node/contributor.ts
@@ -25,12 +25,15 @@ export async function getContributors(filePath?: string, options?: GitLogOptions
       .filter(([_, email]) => email)
       .reduce((acc, [name, email]) => {
         if (!acc[email]) {
+          const githubUsername = guessGitHubUsername(email)
           acc[email] = {
             count: 0,
             name,
             email,
-            avatar: gravatar.url(email),
-            github: guessGitHubUsername(email),
+            avatar: githubUsername
+              ? `https://github.com/${githubUsername}.png`
+              : gravatar.url(email),
+            github: githubUsername ? `https://github.com/${githubUsername}` : null,
             hash: md5(email),
           }
         }

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -13,5 +13,5 @@ export function parseGithubUrl(url: string) {
 
 export function guessGitHubUsername(email: string): string | null {
   const match = email.match(/^(\d+\+)?([^@]+)@users\.noreply\.github\.com$/)
-  return match ? `https://github.com/${match[2]}` : null
+  return match ? match[2] : null
 }


### PR DESCRIPTION
- Update avatar URL to use GitHub profile image when available
- Refactor GitHub username guessing to return username only
- Modify contributor object to include more accurate GitHub profile URL