### PR TITLE
fix: respect Vite base path when fetching git-log.json

### DIFF
--- a/client/composables/gitlog.ts
+++ b/client/composables/gitlog.ts
@@ -24,7 +24,8 @@ export function useGitLog(): Ref<GitLog> {
   const path = frontmatter.value.git_log?.path
 
   if (isPrebuilt && path) {
-    fetch('/git-log.json')
+    const base = import.meta.env.BASE_URL || '/'
+    fetch(`${base}git-log.json`)
       .then(res => res.json())
       .then((data: GitLogFileEntry) => {
         if (data[path])


### PR DESCRIPTION
## Summary

- Fix `fetch('/git-log.json')` failing with 404 when site is deployed to a subpath (e.g. `vite.base: '/docs/'`)
- Use `import.meta.env.BASE_URL` to construct the correct fetch URL

## Context

When deploying a Valaxy site to GitHub Pages at a subpath like `https://example.github.io/docs/`, users configure `vite: { base: '/docs/' }`. The `git-log.json` file is correctly placed in `public/` and served at `/docs/git-log.json`, but the hardcoded `fetch('/git-log.json')` path doesn't include the base prefix.

This forces users to manually patch the addon (see https://github.com/qwqnt-community/docs/blob/main/patches/valaxy-addon-git-log%400.4.2.patch).

Closes YunYouJun/valaxy#695

## Test plan

- [ ] Deploy a Valaxy site with `vite.base: '/subpath/'` and `valaxy-addon-git-log` using `strategy: 'prebuilt'`
- [ ] Verify `git-log.json` is fetched from `/subpath/git-log.json` instead of `/git-log.json`
- [ ] Verify contributors are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)